### PR TITLE
Move to themes directory and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ based systems. This is a clean and minimal black theme for it.
     though it will depend on where you mount your ESP and where rEFInd is
     installed. `fdisk -l` and `mount` may help.
 
- 2. Clone this repository into your refind configuration directory.
+ 2. Create a folder called `themes` inside it, if it doesn't already exist
 
- 3. To enable the theme add `include rEFInd-minimal/theme.conf` at the end of
+ 3. Clone this repository into the `themes` directory.
+
+ 4. To enable the theme add `include themes/rEFInd-minimal-black/theme.conf` at the end of
     `refind.conf`.
 
 Here's an example menuentry configuration (from the screenshot)

--- a/theme.conf
+++ b/theme.conf
@@ -24,7 +24,7 @@ hideui singleuser,hints,arrows,label,badges
 # icons in your own directory and rely on the default for others.
 # Default is "icons".
 #
-icons_dir rEFInd-minimal-black/icons
+icons_dir themes/rEFInd-minimal-black/icons
 
 # Use a custom title banner instead of the rEFInd icon and name. The file
 # path is relative to the directory where refind.efi is located. The color
@@ -32,7 +32,7 @@ icons_dir rEFInd-minimal-black/icons
 # for the menu screens. Currently uncompressed BMP images with color
 # depths of 24, 8, 4 or 1 bits are supported, as well as PNG images.
 #
-banner rEFInd-minimal-black/background.png
+banner themes/rEFInd-minimal-black/background.png
 
 # Tells rEFInd whether to display banner images pixel-for-pixel (noscale)
 # or to scale banner images to fill the screen (fillscreen). The former is
@@ -51,8 +51,8 @@ banner_scale fillscreen
 # or a PNG image. The PNG format is required if you need transparency
 # support (to let you "see through" to a full-screen banner).
 #
-selection_big   rEFInd-minimal-black/selection_big.png
-selection_small rEFInd-minimal-black/selection_small.png
+selection_big   themes/rEFInd-minimal-black/selection_big.png
+selection_small themes/rEFInd-minimal-black/selection_small.png
 
 # Which non-bootloader tools to show on the tools line, and in what
 # order to display them:


### PR DESCRIPTION
Since most of the rEFInd themes suggest to be installed in the `themes` dir, I moved this theme there. I also update the README because the installation part was missing the `-black` suffix in the include.